### PR TITLE
dhcp6: update after changes in insomniacslk/dhcp

### DIFF
--- a/internal/dhcp6/dhcp6.go
+++ b/internal/dhcp6/dhcp6.go
@@ -283,7 +283,7 @@ func (c *Client) ObtainOrRenew() bool {
 	for _, opt := range reply.Options() {
 		switch o := opt.(type) {
 		case *dhcpv6.OptIAForPrefixDelegation:
-			t1 := c.timeNow().Add(time.Duration(o.T1()) * time.Second)
+			t1 := c.timeNow().Add(time.Duration(o.T1) * time.Second)
 			if t1.Before(newCfg.RenewAfter) || newCfg.RenewAfter.IsZero() {
 				newCfg.RenewAfter = t1
 			}


### PR DESCRIPTION
As discussed in https://github.com/insomniacslk/dhcp/pull/176, this patch fixes the build failure
that would derive from the changes in the underlying DHCPv6 library.