### PR TITLE
dhcp6: use changed type name.

### DIFF
--- a/internal/dhcp6/dhcp6.go
+++ b/internal/dhcp6/dhcp6.go
@@ -124,7 +124,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 
 		duid = &dhcpv6.Duid{
 			Type:          dhcpv6.DUID_LLT,
-			HwType:        iana.HwTypeEthernet,
+			HwType:        iana.HWTypeEthernet,
 			Time:          dhcpv6.GetTime(),
 			LinkLayerAddr: iface.HardwareAddr,
 		}


### PR DESCRIPTION
Merge after https://github.com/insomniacslk/dhcp/pull/226 is merged, which changes this type.

You should start using go modules!