### PR TITLE
internal/dhcp6: fix build after dependency update

### DIFF
--- a/internal/dhcp6/dhcp6.go
+++ b/internal/dhcp6/dhcp6.go
@@ -45,8 +45,8 @@ type ClientConfig struct {
 	// be able to carry it around between devices.
 	DUID []byte
 
-	Conn           net.PacketConn // for testing
-	TransactionIDs []uint32       // for testing
+	Conn           net.PacketConn         // for testing
+	TransactionIDs []dhcpv6.TransactionID // for testing
 }
 
 // Config contains the obtained network configuration.
@@ -67,7 +67,7 @@ type Client struct {
 	err error
 
 	Conn           net.PacketConn // TODO: unexport
-	transactionIDs []uint32
+	transactionIDs []dhcpv6.TransactionID
 
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
@@ -124,7 +124,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 
 		duid = &dhcpv6.Duid{
 			Type:          dhcpv6.DUID_LLT,
-			HwType:        iana.HwTypeEthernet,
+			HwType:        iana.HWTypeEthernet,
 			Time:          dhcpv6.GetTime(),
 			LinkLayerAddr: iface.HardwareAddr,
 		}
@@ -283,7 +283,7 @@ func (c *Client) ObtainOrRenew() bool {
 	for _, opt := range reply.Options() {
 		switch o := opt.(type) {
 		case *dhcpv6.OptIAForPrefixDelegation:
-			t1 := c.timeNow().Add(time.Duration(o.T1()) * time.Second)
+			t1 := c.timeNow().Add(time.Duration(o.T1) * time.Second)
 			if t1.Before(newCfg.RenewAfter) || newCfg.RenewAfter.IsZero() {
 				newCfg.RenewAfter = t1
 			}

--- a/internal/dhcp6/dhcp6_test.go
+++ b/internal/dhcp6/dhcp6_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
+	"github.com/insomniacslk/dhcp/dhcpv6"
 )
 
 type packet struct {
@@ -86,9 +87,9 @@ func TestDHCP6(t *testing.T) {
 		InterfaceName: "lo",
 		LocalAddr:     laddr,
 		Conn:          &replayer{pcapr: pcapr},
-		TransactionIDs: []uint32{
-			0x48e59e, // SOLICIT
-			0x738c3b, // REQUEST
+		TransactionIDs: []dhcpv6.TransactionID{
+			dhcpv6.TransactionID{0x48, 0xe5, 0x9e}, // SOLICIT
+			dhcpv6.TransactionID{0x73, 0x8c, 0x3b}, // REQUEST
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
In https://github.com/insomniacslk/dhcp/pull/235 the dhcpv6 interface has changed, and will cause build errors to router7. This PR fixes the build.