### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/testing/pcapreplayer/pcapreplayer.go
+++ b/internal/testing/pcapreplayer/pcapreplayer.go
@@ -130,7 +130,7 @@ type packetConn struct {
 	pcapw *pcapgo.Writer
 }
 
-// NewPCAP returns a net.PacketConn which replays packets from pcap file input,
+// NewPacketConn returns a net.PacketConn which replays packets from pcap file input,
 // writing packets to pcap file output (if non-empty).
 //
 // See https://en.wikipedia.org/wiki/Pcap for details on pcap.


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?