### PR TITLE
dhcp6: use NewSolicit instead of removed NewSolicitForInterface

### DIFF
--- a/internal/dhcp6/dhcp6.go
+++ b/internal/dhcp6/dhcp6.go
@@ -217,7 +217,11 @@ func (c *Client) sendReceive(packet *dhcpv6.Message, expectedType dhcpv6.Message
 func (c *Client) solicit(solicit *dhcpv6.Message) (*dhcpv6.Message, *dhcpv6.Message, error) {
 	var err error
 	if solicit == nil {
-		solicit, err = dhcpv6.NewSolicitForInterface(c.interfaceName, dhcpv6.WithClientID(*c.duid))
+		iface, err := net.InterfaceByName(c.interfaceName)
+		if err != nil {
+			return nil, nil, err
+		}
+		solicit, err = dhcpv6.NewSolicit(iface.HardwareAddr, dhcpv6.WithClientID(*c.duid))
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
In https://github.com/insomniacslk/dhcp/pull/256 NewSolicitForInterface
was removed in favour of NewSolicit. This PR fixes the build failure due
to that change.