### PR TITLE
Fix build after insomniacslk/dhcp constant moved

### DIFF
--- a/internal/dhcp6/dhcp6.go
+++ b/internal/dhcp6/dhcp6.go
@@ -105,7 +105,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	raddr := cfg.RemoteAddr
 	if raddr == nil {
 		raddr = &net.UDPAddr{
-			IP:   client6.AllDHCPRelayAgentsAndServers,
+			IP:   dhcpv6.AllDHCPRelayAgentsAndServers,
 			Port: dhcpv6.DefaultServerPort,
 		}
 	}


### PR DESCRIPTION
The `AllDHCPRelayAgentsAndServers` constant has moved from `client6` to
`dhcpv6` in `insomniacslk/dhcp` . This PR fixes the build after
https://github.com/insomniacslk/dhcp/pull/278

Signed-off-by: Andrea Barberio <insomniac@slackware.it>