### PR TITLE
dhcp6: use new IAPD & Prefix getters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/gopacket v1.1.17
 	github.com/google/nftables v0.0.0-20200210101420-1c56a1906fbf
 	github.com/google/renameio v0.1.0
-	github.com/insomniacslk/dhcp v0.0.0-20200306230118-99cbb09fb7b9
+	github.com/insomniacslk/dhcp v0.0.0-20200311205251-eed709df9494
 	github.com/jpillora/backoff v1.0.0
 	github.com/krolaw/dhcp4 v0.0.0-20190909130307-a50d88189771
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/insomniacslk/dhcp v0.0.0-20200210095418-45e5f320b2f0 h1:jzkAy3xl8j58y
 github.com/insomniacslk/dhcp v0.0.0-20200210095418-45e5f320b2f0/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/insomniacslk/dhcp v0.0.0-20200306230118-99cbb09fb7b9 h1:5gifC0gFQ6VowQOXA1Yn1z4NFXlWRLbDT3oFxIZowJk=
 github.com/insomniacslk/dhcp v0.0.0-20200306230118-99cbb09fb7b9/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
+github.com/insomniacslk/dhcp v0.0.0-20200311205251-eed709df9494 h1:KDhUkNE73wlQNDk9xW8anpphV9vDiPZNwfgVC5yHmhk=
+github.com/insomniacslk/dhcp v0.0.0-20200311205251-eed709df9494/go.mod h1:CfMdguCK66I5DAUJgGKyNz8aB6vO5dZzkm9Xep6WGvw=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=


### PR DESCRIPTION
wasn't sure if you wanted to process all Prefixes in the IAPrefix message, or just one as previously. so that's a tiny bit of a logic change, not just a lib updated.

also wondering what you think of using & contributing to https://godoc.org/github.com/insomniacslk/dhcp/dhcpv6/nclient6? what's missing there that I should take a look at if you were to use it?

thanks!