### PR TITLE
dhcp4d: ensure that SetHostname operates on the correct lease

### DIFF
--- a/cmd/dhcp4d/dhcp4d.go
+++ b/cmd/dhcp4d/dhcp4d.go
@@ -279,7 +279,10 @@ func newSrv(permDir string) (*srv, error) {
 			http.Error(w, "missing hostname parameter", http.StatusBadRequest)
 			return
 		}
-		handler.SetHostname(hwaddr, hostname)
+		if err := handler.SetHostname(hwaddr, hostname); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		http.Redirect(w, r, "/", http.StatusFound)
 	})
 


### PR DESCRIPTION
Previously SetHostname could operate on an expired lease, or even on a
lease for a different hwaddr, if the lease for the correct hwaddr
expired and the same lease ID was given away to someone else.

That's though mostly a theoretical concern, given the actual usage of
SetHostname and the time scales involved.