### PR TITLE
fix CONTRIBUTING.md link on the website

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -10,7 +10,7 @@ menu:
 
 router7 is a pure-Go implementation of a small home internet router. It comes with all the services required to make a [fiber7 internet connection](https://www.init7.net/en/internet/fiber7/) work (DHCPv4, DHCPv6, DNS, etc.).
 
-Note that this project should be considered a (working!) tech demo. Feature requests will likely not be implemented, and see [CONTRIBUTING.md](CONTRIBUTING.md) for details about which contributions are welcome.
+Note that this project should be considered a (working!) tech demo. Feature requests will likely not be implemented, and see [CONTRIBUTING.md](https://github.com/rtr7/router7/blob/master/CONTRIBUTING.md) for details about which contributions are welcome.
 
 ## Motivation
 


### PR DESCRIPTION
Fix the  link to CONTRIBUTING.md on router7.org which is a 404 because of the way github pages works.

Or was "Feature requests will likely not be implemented, and see CONTRIBUTING.md ..." being followed by a 404 link on purpose so you have less work with contributions? If it was then I approve of this epic trolling. 😃 